### PR TITLE
feat: add navigation dropdown component

### DIFF
--- a/src/components/molecules/NavDropdown/NavDropdown.astro
+++ b/src/components/molecules/NavDropdown/NavDropdown.astro
@@ -1,0 +1,207 @@
+---
+/**
+ * NavDropdown Molecule
+ * WordPress reference: /wordpress-source/assets/css/header.css
+ * Desktop styles: 66-111
+ * Mobile styles: 700-742
+ */
+
+import { semantic } from '../../../tokens/semantic';
+import { component } from '../../../tokens/component';
+
+export interface NavDropdownColumn {
+  title: string;
+  links: Array<{ label: string; href: string }>;
+}
+
+export interface NavDropdownProps {
+  columns: NavDropdownColumn[];
+  variant?: 'default' | 'calc';
+  report?: {
+    title: string;
+    descr: string;
+    link: { label: string; href: string };
+  };
+}
+
+const {
+  columns = [],
+  variant = 'default',
+  report,
+} = Astro.props as NavDropdownProps;
+---
+<div class={`hg-dropdown ${variant === 'calc' ? 'hg-dropdown--calc' : ''}`}>
+  <div class="hg-dropdown__columns">
+    {columns.map((column) => (
+      <div class="hg-dropdown__column">
+        <div class="hg-dropdown__title">{column.title}</div>
+        <ul class="hg-dropdown__list">
+          {column.links.map((link) => (
+            <li class="hg-dropdown__item">
+              <a href={link.href} class="hg-dropdown__link">{link.label}</a>
+            </li>
+          ))}
+        </ul>
+      </div>
+    ))}
+  </div>
+  {variant === 'calc' && report && (
+    <div class="hg-dropdown__report">
+      <div class="hg-dropdown__report-title">{report.title}</div>
+      <div class="hg-dropdown__report-descr">{report.descr}</div>
+      <a href={report.link.href} class="hg-dropdown__report-btn">{report.link.label}</a>
+    </div>
+  )}
+</div>
+<style is:global define:vars={{
+  brandPrimary: semantic.color.brand.primary,
+  textPrimary: semantic.color.text.primary,
+  spaceXs: semantic.space.xs,
+  spaceSm: semantic.space.sm,
+  spaceMd: semantic.space.md,
+  spaceLg: semantic.space.lg,
+  fontSizeSm: semantic.typography.size.sm,
+  fontSizeMd: semantic.typography.size.md,
+  fontWeightBold: semantic.typography.weight.bold,
+  radiusSm: semantic.radius.sm,
+  durationNormal: semantic.duration.normal,
+  dropdownBg: component.navigation.dropdown.background,
+  dropdownRadius: component.navigation.dropdown.borderRadius,
+  dropdownShadow: component.navigation.dropdown.shadow,
+  dropdownPadding: component.navigation.dropdown.padding,
+  dropdownWidth: component.navigation.dropdown.width,
+  dropdownWidthCalc: component.navigation.dropdown.widthCalc,
+  columnGap: component.navigation.dropdown.gap,
+  columnMinWidth: component.navigation.dropdown.columnMinWidth,
+  reportMaxWidth: component.navigation.dropdown.report.maxWidth,
+  reportPaddingLeft: component.navigation.dropdown.report.paddingLeft,
+  reportBorderLeft: component.navigation.dropdown.report.borderLeft,
+  mobileTop: component.navigation.dropdown.mobile.top,
+  mobilePadding: component.navigation.dropdown.mobile.padding,
+}}>
+.hg-dropdown {
+  background: var(--dropdownBg);
+  border-radius: var(--dropdownRadius);
+  box-shadow: var(--dropdownShadow);
+  padding: var(--dropdownPadding);
+  width: var(--dropdownWidth);
+  display: none;
+  opacity: 0;
+  transform: translateX(-50%) translateY(-10px);
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transition: all var(--durationNormal) ease;
+  z-index: 1000;
+}
+
+.hg-dropdown--calc {
+  width: var(--dropdownWidthCalc);
+  display: flex;
+  gap: var(--columnGap);
+}
+
+.hg-dropdown__columns {
+  display: flex;
+  gap: var(--columnGap);
+}
+
+.hg-dropdown__column {
+  min-width: var(--columnMinWidth);
+}
+
+.hg-dropdown__title {
+  font-weight: var(--fontWeightBold);
+  font-size: var(--fontSizeMd);
+  margin-bottom: var(--spaceMd);
+}
+
+.hg-dropdown__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+ .hg-dropdown__item + .hg-dropdown__item {
+  margin-top: var(--spaceMd);
+ }
+
+.hg-dropdown__link {
+  text-decoration: none;
+  color: var(--textPrimary);
+  font-size: var(--fontSizeSm);
+  transition: color var(--durationNormal) ease;
+}
+
+.hg-dropdown__link:hover {
+  color: var(--brandPrimary);
+}
+
+.hg-dropdown__report {
+  border-left: 1px solid var(--reportBorderLeft);
+  padding-left: var(--reportPaddingLeft);
+  max-width: var(--reportMaxWidth);
+}
+
+.hg-dropdown__report-title {
+  font-weight: var(--fontWeightBold);
+  font-size: var(--fontSizeMd);
+  margin-bottom: var(--spaceMd);
+}
+
+.hg-dropdown__report-descr {
+  font-size: var(--fontSizeSm);
+  margin-bottom: var(--spaceMd);
+}
+
+.hg-dropdown__report-btn {
+  display: inline-block;
+  background: var(--brandPrimary);
+  color: var(--dropdownBg);
+  padding: var(--spaceXs) var(--spaceSm);
+  border-radius: var(--radiusSm);
+  font-size: var(--fontSizeSm);
+  text-decoration: none;
+  transition: opacity var(--durationNormal) ease;
+}
+
+.hg-dropdown__report-btn:hover {
+  opacity: 0.85;
+}
+
+@media (max-width: 991px) {
+  .hg-dropdown {
+    position: fixed;
+    display: block !important;
+    width: auto;
+    transform: none;
+    top: var(--mobileTop);
+    bottom: 0;
+    overflow: auto;
+    padding: var(--mobilePadding);
+    box-shadow: none;
+    left: 100%;
+    right: -100%;
+  }
+
+  .hg-dropdown.active {
+    left: 0;
+    right: 0;
+  }
+
+  .hg-dropdown__columns {
+    display: block;
+  }
+
+  .hg-dropdown__column + .hg-dropdown__column {
+    margin-top: var(--spaceLg);
+  }
+
+  .hg-dropdown__report {
+    border-left: none;
+    padding-left: 0;
+    max-width: 100%;
+    margin-top: var(--spaceLg);
+  }
+}
+</style>

--- a/src/components/molecules/index.ts
+++ b/src/components/molecules/index.ts
@@ -8,6 +8,7 @@ export { default as StatCard } from './StatCard/StatCard.astro';
 export { default as PurposeCard } from './PurposeCard/PurposeCard.astro';
 export { default as AwardItem } from './AwardItem/AwardItem.astro';
 export { default as Tooltip } from './Tooltip/Tooltip.astro';
+export { default as NavDropdown } from './NavDropdown/NavDropdown.astro';
 
 // Export types
 export type { StatCardProps } from './StatCard/StatCard.types';

--- a/src/components/navigation/Header.astro
+++ b/src/components/navigation/Header.astro
@@ -10,36 +10,109 @@ import Logo from '../atoms/Logo/Logo.astro';
 import Button from '../atoms/Button/Button.astro';
 import Icon from '../atoms/Icon/Icon.astro';
 import PhoneLink from '../molecules/PhoneLink/PhoneLink.astro';
+import NavDropdown from '../molecules/NavDropdown/NavDropdown.astro';
 import { semantic } from '../../tokens/semantic';
 
-// WordPress menu structure - matching ACF structure
+// WordPress menu structure replicated with Astro components
 const menuItems = [
-  { 
-    label: 'Home Loans', 
+  {
+    label: 'Home Loans',
     href: '/home-loans',
     hasDropdown: true,
-    megaMenu: true 
+    columns: [
+      {
+        title: 'Buy',
+        links: [
+          { label: 'First Home Buyer Loans', href: '/first-home-buyer-loans' },
+          { label: 'Upgrade My Home', href: '/upgrade-my-home' },
+        ],
+      },
+      {
+        title: 'Refinance',
+        links: [
+          { label: 'Refinance Home Loan', href: '/refinance-home-loan' },
+          { label: 'Lower Your Rate', href: '/lower-your-rate' },
+        ],
+      },
+      {
+        title: 'Invest',
+        links: [
+          { label: 'Property Investor Portfolio', href: '/property-investor-portfolio' },
+          { label: 'Your Property Investment Journey', href: '/your-property-investment-journey' },
+        ],
+      },
+    ],
   },
-  { 
-    label: 'Calculators', 
+  {
+    label: 'Calculators',
     href: '/calculators',
     hasDropdown: true,
-    special: 'calc' // Special calc dropdown styling
+    dropdownVariant: 'calc',
+    columns: [
+      {
+        title: 'Calculators',
+        links: [
+          { label: 'Mortgage Calculator', href: '/mortgage-calculator' },
+          { label: 'Mortgage vs Rent Calculator', href: '/mortgage-vs-rent-calculator' },
+        ],
+      },
+      {
+        title: 'Reports',
+        links: [
+          { label: 'Mortgage Report', href: '/mortgage-report' },
+        ],
+      },
+    ],
+    report: {
+      title: 'Free Property Report',
+      descr: 'See how much your property is worth.',
+      link: { label: 'Get Report', href: '/mortgage-report' },
+    },
   },
-  { 
-    label: 'Resources', 
+  {
+    label: 'Resources',
     href: '/resources',
     hasDropdown: true,
-    megaMenu: true
+    columns: [
+      {
+        title: 'Guides',
+        links: [
+          { label: 'What We Do', href: '/whatwedo' },
+          { label: 'Who We Help', href: '/whowehelp' },
+        ],
+      },
+      {
+        title: 'Team',
+        links: [
+          { label: 'Our Team', href: '/ourteam' },
+          { label: 'Contact', href: '/contact' },
+        ],
+      },
+      {
+        title: 'Blog',
+        links: [
+          { label: 'Mortgage Broker Brisbane Blog', href: '/blog' },
+        ],
+      },
+    ],
   },
-  { 
-    label: 'Brisbane', 
-    href: '/brisbane' 
+  {
+    label: 'Brisbane',
+    href: '/brisbane',
   },
-  { 
-    label: 'About', 
+  {
+    label: 'About',
     href: '/about',
-    hasDropdown: true 
+    hasDropdown: true,
+    columns: [
+      {
+        title: 'About Us',
+        links: [
+          { label: 'Our Team', href: '/ourteam' },
+          { label: 'Contact', href: '/contact' },
+        ],
+      },
+    ],
   },
 ];
 ---
@@ -61,13 +134,12 @@ const menuItems = [
               )}
             </a>
             
-            {/* Dropdown placeholder - will be implemented with navigation molecules */}
             {item.hasDropdown && (
-              <div class={`hg-dropdown ${item.special === 'calc' ? 'hg-dropdown--calc' : ''}`} data-dropdown-menu>
-                <div class="hg-dropdown__content">
-                  <p>Dropdown for {item.label} - To be implemented</p>
-                </div>
-              </div>
+              <NavDropdown
+                columns={item.columns}
+                variant={item.dropdownVariant}
+                report={item.report}
+              />
             )}
           </li>
         ))}
@@ -213,33 +285,7 @@ const menuItems = [
   color: var(--brandPrimary);
 }
 
-/* Dropdown Menus */
-.hg-dropdown {
-  position: absolute;
-  top: 100%;
-  left: 50%;
-  transform: translateX(-50%);
-  background: var(--surfaceWhite);
-  border-radius: 12px;
-  box-shadow: 0px 10px 40px rgba(0, 0, 0, 0.1);
-  padding: 30px;
-  min-width: 735px; /* WordPress dropdown width */
-  display: none;
-  opacity: 0;
-  transform: translateX(-50%) translateY(-10px);
-  transition: all 0.3s ease;
-  z-index: 1000;
-}
-
-.hg-dropdown--calc {
-  min-width: 770px; /* WordPress calc dropdown width */
-}
-
-.hg-nav-item:hover .hg-dropdown {
-  display: block;
-  opacity: 1;
-  transform: translateX(-50%) translateY(0);
-}
+/* Dropdown Menus handled via NavDropdown component and JS */
 
 /* Navigation Actions */
 .hg-nav-actions {

--- a/src/tokens/component.ts
+++ b/src/tokens/component.ts
@@ -5,6 +5,7 @@
  */
 
 import { semantic } from './semantic';
+import { primitive } from './primitive';
 
 export const component = {
   // Button component tokens
@@ -127,7 +128,7 @@ export const component = {
 
   // Tooltip component tokens
   tooltip: {
-    background: semantic.color.gray[800],
+    background: primitive.color.gray[800],
     text: semantic.color.text.inverse,
     borderRadius: semantic.radius.sm,
     padding: semantic.space.sm,
@@ -144,6 +145,26 @@ export const component = {
     linkColor: semantic.color.text.primary,
     linkHoverColor: semantic.color.brand.primary,
     padding: semantic.space.sm,
+
+    dropdown: {
+      background: semantic.color.surface.white,
+      borderRadius: semantic.radius.dropdown,
+      shadow: semantic.shadow.dropdown,
+      padding: '30px 30px 17px', // WordPress dropdown padding
+      width: '735px',            // Default dropdown width
+      widthCalc: '770px',        // Calculator dropdown width
+      gap: semantic.space.lg,
+      columnMinWidth: '200px',
+      report: {
+        maxWidth: '220px',
+        paddingLeft: semantic.space.lg,
+        borderLeft: semantic.color.border.primary,
+      },
+      mobile: {
+        top: '57px',
+        padding: semantic.space.md,
+      },
+    },
   },
 
   // Section component tokens

--- a/src/tokens/primitive.ts
+++ b/src/tokens/primitive.ts
@@ -99,8 +99,9 @@ export const primitive = {
   borderRadius: {
     none: '0',
     sm: '4px',
-    md: '12px', 
+    md: '12px',
     lg: '24px',
+    dropdown: '8px',
     full: '9999px',
   },
 
@@ -109,6 +110,7 @@ export const primitive = {
     sm: '0 1px 2px rgba(0, 0, 0, 0.05)',
     md: '0 4px 8px rgba(0, 0, 0, 0.1)',
     lg: '0 8px 30px rgba(0, 0, 0, 0.15)',
+    dropdown: '0px 2px 10px rgba(0, 0, 0, 0.15)',
   },
 
   // Timing values

--- a/src/tokens/semantic.ts
+++ b/src/tokens/semantic.ts
@@ -125,6 +125,7 @@ export const semantic = {
     sm: primitive.borderRadius.sm,        // Tooltips, small elements
     md: primitive.borderRadius.md,        // Cards, inputs
     lg: primitive.borderRadius.lg,        // Large cards
+    dropdown: primitive.borderRadius.dropdown, // WordPress dropdowns
     pill: primitive.borderRadius.full,    // Buttons, badges
   },
 
@@ -132,8 +133,9 @@ export const semantic = {
   shadow: {
     sm: primitive.shadow.sm,              // Small shadows
     subtle: primitive.shadow.sm,          // Subtle elevation
-    card: primitive.shadow.md,            // Card elevation  
+    card: primitive.shadow.md,            // Card elevation
     prominent: primitive.shadow.lg,       // Prominent elevation
+    dropdown: primitive.shadow.dropdown,  // WordPress dropdowns
   },
 
   // Animation timing by role


### PR DESCRIPTION
## Summary
- document WordPress header dropdown reference and integrate responsive behavior
- replace hardcoded dropdown styles with semantic/component tokens
- add dropdown-specific tokens in primitive and semantic layers

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6892f44f0e5c8331a6c481e8efa19cda