### PR TITLE
fix(netlify): avoid importing vite in astro.config; update PR templat…

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,7 +20,7 @@ Describe what this PR changes and why.
 ## Checklist (SOP compliance)
 
 - [ ] Followed `instructions.md` reuse flow (organism → molecule → atom; variants preferred)
-- [ ] Added a demo block to `src/pages/design-system.astro`
+- [ ] Added/updated `/design-system/review` demo route(s)
 - [ ] No hardcoded styles; tokens via `define:vars`
 - [ ] Branch is correctly named (`feat/...`, `fix/...`, etc.)
 - [ ] Ran local checks: `npm run build` and `npm run check:tokens`

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,16 +2,15 @@
 import { defineConfig } from 'astro/config';
 import tailwindcss from '@tailwindcss/vite';
 import react from '@astrojs/react';
-import { loadEnv } from 'vite';
 import astrobook from 'astrobook';
 
-const env = loadEnv(process.env.NODE_ENV || 'production', process.cwd(), '');
+// Avoid importing 'vite' in config on CI (Netlify) to prevent missing direct dep resolution
 
 // https://astro.build/config
 const enableAstrobook = process.env.ASTROBOOK === 'true' || process.env.NODE_ENV === 'development';
 
 export default defineConfig({
-  site: env.PUBLIC_SITE_URL || 'http://localhost:4321',
+  site: process.env.PUBLIC_SITE_URL || 'http://localhost:4321',
   
   vite: {
     plugins: [tailwindcss()]

--- a/src/pages/legacy/header-old.astro
+++ b/src/pages/legacy/header-old.astro
@@ -1,6 +1,6 @@
 ---
 import Layout from '../../layouts/Layout.astro';
-import LegacyHeader from '../../../hunter-galloway-astro-with-CI/hunter-galloway-astro/src/components/navigation/Header.astro';
+import LegacyHeader from '../../components/organisms/Header.astro';
 ---
 
 <Layout title="Header (Legacy)">


### PR DESCRIPTION
…e for review route

### Reuse & Registry
- [ ] Reused existing component (link) OR added row to docs/COMPONENTS.md
- [ ] Checked for near-duplicates

### Demo
- [ ] Added/updated /design-system/review demo route(s)
- [ ] (Optional) Used `pnpm snap` – screenshots attached in PR artifacts

### Rules
- [ ] No hard-coded styles (tokens only)
- [ ] Correct atomic level & naming

### Parity (close replica OK)
- Notable deviations from reference and why:

## Summary

Describe what this PR changes and why.

## Checklist (SOP compliance)

- [ ] Followed `instructions.md` reuse flow (organism → molecule → atom; variants preferred)
- [ ] Added a demo block to `src/pages/design-system.astro`
- [ ] No hardcoded styles; tokens via `define:vars`
- [ ] Branch is correctly named (`feat/...`, `fix/...`, etc.)
- [ ] Ran local checks: `npm run build` and `npm run check:tokens`
- [ ] Updated `workflow_state.md` (decision, logs, results)

## Screenshots / Demos

Paste screenshots or links to local `/design-system`.


